### PR TITLE
LO-12: Add delete functionality

### DIFF
--- a/backend-flask/app/models/level.py
+++ b/backend-flask/app/models/level.py
@@ -4,7 +4,7 @@ class Level(db.Model):
     __tablename__ = 'level'
     
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    student_id = db.Column(db.Integer, db.ForeignKey('student.id'), nullable=False)
+    student_id = db.Column(db.Integer, db.ForeignKey('student.id', ondelete='CASCADE'), nullable=False)
     start_date = db.Column(db.DateTime, nullable=False)
     level_category = db.Column(db.String, nullable=False)
     

--- a/backend-flask/app/models/quiz.py
+++ b/backend-flask/app/models/quiz.py
@@ -8,8 +8,8 @@ class Quiz(db.Model):
     datetime = db.Column(db.DateTime, nullable=False)
     score = db.Column(db.Float, nullable=False)
     notes = db.Column(db.String)
-    lesson_id = db.Column(db.Integer, db.ForeignKey('lesson.id'), nullable=False)
-    student_id = db.Column(db.Integer, db.ForeignKey('student.id'), nullable=False)
+    lesson_id = db.Column(db.Integer, db.ForeignKey('lesson.id'))
+    student_id = db.Column(db.Integer, db.ForeignKey('student.id'))
     
     lesson = db.relationship('Lesson', back_populates='quizzes')
     student = db.relationship('Student', back_populates='quizzes')

--- a/backend-flask/app/routes/lessons.py
+++ b/backend-flask/app/routes/lessons.py
@@ -42,8 +42,9 @@ def update_lesson(id):
     return lesson_schema.dump(updated_lesson)
 
 @lessons_bp.route('/lessons/<int:id>', methods=['DELETE'])
+@response_wrapper
 def delete_lesson(id):
     lesson = Lesson.query.get_or_404(id)
     db.session.delete(lesson)
     db.session.commit()
-    return jsonify({"message": "Lesson deleted successfully"}), 204
+    return '', 204

--- a/backend-flask/app/routes/utils.py
+++ b/backend-flask/app/routes/utils.py
@@ -1,4 +1,4 @@
-from flask import jsonify
+from flask import jsonify, make_response
 from functools import wraps
 
 def response_wrapper(func):
@@ -6,16 +6,36 @@ def response_wrapper(func):
     def wrapped_function(*args, **kwargs):
         try:
             result = func(*args, **kwargs)
-            response = {
-                "status": "success", 
-                "data": result
-            }
-            return jsonify(response), 200
+            if isinstance(result, tuple) and len(result) == 2:
+                data, status_code = result
+            else:
+                data, status_code = result, 200
+
+            # Define the response variable before using it
+            response = {}
+
+            if status_code == 204:
+                response = {
+                    "status": "success",
+                    "message": "No Content"
+                }
+                return make_response(jsonify(response), 204)
+
+            if isinstance(data, dict) and "message" in data:
+                response = {
+                    "status": "success",
+                    "message": data["message"]
+                }
+            else:
+                response = {
+                    "status": "success",
+                    "data": data
+                }
+            return jsonify(response), status_code
         except Exception as e:
             response = {
-                "status": "error", 
+                "status": "error",
                 "message": str(e)
             }
             return jsonify(response), 500
     return wrapped_function
-                

--- a/frontend-svelte/src/api/apiClient.ts
+++ b/frontend-svelte/src/api/apiClient.ts
@@ -46,6 +46,10 @@ export async function apiRequest<T>(endpoint: string, method: string = 'GET', bo
     if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
     }
+
+    if (response.status === 204) {
+        return {} as T;
+    }
     
     const jsonResponse: JSendResponse<T> = await response.json();
 

--- a/frontend-svelte/src/api/lesson.ts
+++ b/frontend-svelte/src/api/lesson.ts
@@ -9,3 +9,7 @@ export async function fetchLessons(params: QueryParams = {}): Promise<Lesson[]> 
 export async function createLesson(lesson: Partial<Lesson>): Promise<Lesson> {
     return await apiRequest<Lesson>('/lessons', 'POST', lesson);
 }
+
+export async function deleteLesson(id: number): Promise<void> {
+    await apiRequest<void>(`/lessons/${id}`, 'DELETE');
+}

--- a/frontend-svelte/src/lib/components/LessonCard.svelte
+++ b/frontend-svelte/src/lib/components/LessonCard.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { Lesson } from "../../types";
+  import { deleteLesson } from "../../api/lesson";
+  import { lessonState } from "$lib/states/lessonState.svelte";
 
   let { lesson }: { lesson: Lesson } = $props();
 
@@ -16,14 +18,27 @@
   let concepts: string = lesson.concepts;
   let notes: string = lesson.notes;
 
+  async function handleDelete() {
+    if (confirm("Are you sure you want to delete this lesson?")) {
+      await deleteLesson(lesson.id);
+      lessonState.lessons = lessonState.lessons.filter(l => l.id !== lesson.id);
+    }
+  }
 </script>
 
 <div class="m-4 w-64 rounded bg-neutral">
+  <div class="flex justify-end space-x-2 mb-2">
+    <button onclick={handleDelete} class="btn btn-ghost btn-sm text-error items-center p-1">
+      <span class="mr-2">Delete</span>
+    </button>
+  </div>
   <div class="flex flex-col space-y-2 p-2">
     <p>{weekday}</p>
     <p>{date}:</p>
     <p>{time}:</p>
     <p>{student}</p>
+  </div>
+  <div class="flex flex-col space-y-2 p-2">
     <div>
       <p>Today's plan:</p>
       <p class="min-h-24">

--- a/frontend-svelte/src/lib/components/LessonCreateModal.svelte
+++ b/frontend-svelte/src/lib/components/LessonCreateModal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createLesson } from "../../api/lesson";
   import type { Lesson } from "../../types";
+  import { lessonState } from "$lib/states/lessonState.svelte";
 
   export let date = "";
   export let time = "";
@@ -31,9 +32,8 @@
 
     try {
       const createdLesson = await createLesson(newLesson);
-      console.log("Lesson created:", createdLesson);
+      lessonState.lessons.push(createdLesson);
       lessonCreateModal.close();
-      location.reload()
     } catch (error) {
       console.error("Error creating lesson:", error);
     }
@@ -43,6 +43,11 @@
 <button
   class="btn btn-secondary"
   on:click={() => {
+    date = "";
+    time = "";
+    plan = "";
+    concepts = "";
+    notes = "";
     lessonCreateModal.showModal();
   }}
 >

--- a/frontend-svelte/src/lib/states/lessonState.svelte.ts
+++ b/frontend-svelte/src/lib/states/lessonState.svelte.ts
@@ -1,0 +1,7 @@
+import type { Lesson } from "../../types";
+
+interface LessonState {
+  lessons: Lesson[];
+}
+
+export const lessonState = $state<LessonState>({ lessons: [] });

--- a/frontend-svelte/src/routes/+page.svelte
+++ b/frontend-svelte/src/routes/+page.svelte
@@ -4,12 +4,11 @@
   import LessonCreateModal from "$lib/components/LessonCreateModal.svelte";
   import type { Lesson } from "../types";
   import { fetchLessons } from "../api/lesson"
-
-  let lessons: Lesson[] = [];
+import { lessonState } from "$lib/states/lessonState.svelte";
 
   onMount(async () => {
     try {
-      lessons = await fetchLessons();
+      lessonState.lessons = await fetchLessons();
     } catch (error) {
       console.error("Error fetching lessons:", error);
     }
@@ -28,7 +27,7 @@
   </div>
 </div>
 <div class="flex flex-row">
-  {#each lessons as lesson}
+  {#each lessonState.lessons as lesson (lesson.id)}
     <div class="flex flex-col space-y-4">
       <LessonCard
         lesson={lesson}


### PR DESCRIPTION
TODOs completed:
- updated backend model foreign keys to allow deletion of lessons
- updated backend response wrapper to handle 204 responses
- added delete button to lesson card components
- currently viewed lessons are now stored in a state rune to allow for universal reactivity
- updated creation and deletion to no longer need a page refresh to refetch data; the lesson state is now updated separately to the backend