### PR TITLE
LO-31: Frontend lesson state does not update correctly on edit confirm

### DIFF
--- a/frontend-svelte/src/lib/components/LessonCard.svelte
+++ b/frontend-svelte/src/lib/components/LessonCard.svelte
@@ -32,7 +32,7 @@
     const datetime = new Date(`${dateInput}T${timeInput}`).toISOString();
     const updatedLesson = { ...lesson, datetime, plan, concepts, notes };
     await updateLesson(updatedLesson);
-    lesson.datetime = datetime;
+    lesson = updatedLesson;
     isEditing = false;
   }
 

--- a/frontend-svelte/src/lib/components/SelectWeek.svelte
+++ b/frontend-svelte/src/lib/components/SelectWeek.svelte
@@ -1,19 +1,10 @@
 <script lang="ts">
+    import { getStartOfWeekInUTC } from "$lib/utils/dateUtils";
+
     let { startDate = $bindable()}: { startDate: Date } = $props();
 
     function updateStartDate(newStartDate: Date) {
-        // Adjust to get week day belongs to
-        const day = newStartDate.getUTCDay();
-        const diff = newStartDate.getUTCDate() - day;
-        const sunday = new Date(newStartDate.setDate(diff));
-        
-        // Set time to midnight local time
-        sunday.setHours(0, 0, 0, 0);
-        
-        // Convert to UTC
-        const utcSunday = new Date(Date.UTC(sunday.getFullYear(), sunday.getMonth(), sunday.getDate(), 0, 0, 0));
-        
-        startDate = utcSunday;
+        startDate = getStartOfWeekInUTC(newStartDate);
     }
 </script>
 

--- a/frontend-svelte/src/lib/utils/dateUtils.ts
+++ b/frontend-svelte/src/lib/utils/dateUtils.ts
@@ -1,0 +1,13 @@
+export function getStartOfWeekInUTC(date: Date): Date {
+    const day = date.getUTCDay();
+    const diff = date.getUTCDate() - day;
+    const sunday = new Date(date.setDate(diff));
+    
+    // Set time to midnight local time
+    sunday.setHours(0, 0, 0, 0);
+    
+    // Convert to UTC
+    const utcSunday = new Date(Date.UTC(sunday.getFullYear(), sunday.getMonth(), sunday.getDate(), 0, 0, 0));
+    
+    return utcSunday;
+}

--- a/frontend-svelte/src/routes/+page.svelte
+++ b/frontend-svelte/src/routes/+page.svelte
@@ -5,8 +5,9 @@
   import SelectWeek from "$lib/components/SelectWeek.svelte";
   import { fetchLessons } from "../api/lesson"
   import { lessonState } from "$lib/states/lessonState.svelte";
+  import { getStartOfWeekInUTC } from "$lib/utils/dateUtils";
 
-  let startDate: Date = $state(new Date())
+  let startDate: Date = $state(getStartOfWeekInUTC(new Date()))
 
   onMount(async () => {
     getLessons();


### PR DESCRIPTION
TODOs completed:
- fixed bug where only the datetime of the lesson state would be updated on the frontend when confirming a lesson edit