### PR TITLE
LO-35: Lessons always populate current week

### DIFF
--- a/frontend-svelte/src/lib/components/LessonCard.svelte
+++ b/frontend-svelte/src/lib/components/LessonCard.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Lesson } from "../../types";
   import { deleteLesson, updateLesson } from "../../api/lesson";
-  import { lessonState } from "$lib/states/lessonState.svelte";
+  import { lessonState, updateLessonInState } from "$lib/states/lessonState.svelte";
 
   let { lesson = $bindable() }: { lesson: Lesson } = $props();
   let isEditing: boolean = $state(false);
@@ -32,7 +32,7 @@
     const datetime = new Date(`${dateInput}T${timeInput}`).toISOString();
     const updatedLesson = { ...lesson, datetime, plan, concepts, notes };
     await updateLesson(updatedLesson);
-    lesson = updatedLesson;
+    updateLessonInState(updatedLesson)
     isEditing = false;
   }
 

--- a/frontend-svelte/src/lib/components/LessonCard.svelte
+++ b/frontend-svelte/src/lib/components/LessonCard.svelte
@@ -23,7 +23,7 @@
   async function handleDelete() {
     if (confirm("Are you sure you want to delete this lesson?")) {
       await deleteLesson(lesson.id);
-      lessonState.lessons = lessonState.lessons.filter(l => l.id !== lesson.id);
+      lessonState.current = lessonState.current.filter(l => l.id !== lesson.id);
       isEditing = false;
     }
   }

--- a/frontend-svelte/src/lib/components/LessonCreateModal.svelte
+++ b/frontend-svelte/src/lib/components/LessonCreateModal.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { createLesson } from "../../api/lesson";
   import type { Lesson } from "../../types";
-  import { lessonState } from "$lib/states/lessonState.svelte";
+  import { lessonState, addLessonToState } from "$lib/states/lessonState.svelte";
+  import { lessonWeekStartDate } from "$lib/states/lessonWeekStartDate.svelte";
 
   export let date = "";
   export let time = "";
@@ -32,7 +33,7 @@
 
     try {
       const createdLesson = await createLesson(newLesson);
-      lessonState.lessons.push(createdLesson);
+      addLessonToState(createdLesson);
       lessonCreateModal.close();
     } catch (error) {
       console.error("Error creating lesson:", error);

--- a/frontend-svelte/src/lib/states/lessonState.svelte.ts
+++ b/frontend-svelte/src/lib/states/lessonState.svelte.ts
@@ -1,7 +1,25 @@
 import type { Lesson } from "../../types";
+import { isWithinOneWeek } from "$lib/utils/dateUtils";
+import { lessonWeekStartDate } from "./lessonWeekStartDate.svelte";
 
 interface LessonState {
   lessons: Lesson[];
 }
 
 export const lessonState = $state<LessonState>({ lessons: [] });
+
+export function addLessonToState(newLesson: Lesson){
+  if (isWithinOneWeek(lessonWeekStartDate.current, new Date(newLesson.datetime))) {
+    lessonState.lessons.push(newLesson);
+  }
+}
+
+export function updateLessonInState(updatedLesson: Lesson) {
+  if (isWithinOneWeek(lessonWeekStartDate.current, new Date(updatedLesson.datetime))) {
+    lessonState.lessons = lessonState.lessons.map(lesson =>
+      lesson.id === updatedLesson.id ? updatedLesson : lesson
+    );
+  } else {
+    lessonState.lessons = lessonState.lessons.filter(lesson => lesson.id !== updatedLesson.id);
+  }
+}

--- a/frontend-svelte/src/lib/states/lessonState.svelte.ts
+++ b/frontend-svelte/src/lib/states/lessonState.svelte.ts
@@ -3,23 +3,23 @@ import { isWithinOneWeek } from "$lib/utils/dateUtils";
 import { lessonWeekStartDate } from "./lessonWeekStartDate.svelte";
 
 interface LessonState {
-  lessons: Lesson[];
+  current: Lesson[];
 }
 
-export const lessonState = $state<LessonState>({ lessons: [] });
+export const lessonState = $state<LessonState>({current: [] });
 
 export function addLessonToState(newLesson: Lesson){
   if (isWithinOneWeek(lessonWeekStartDate.current, new Date(newLesson.datetime))) {
-    lessonState.lessons.push(newLesson);
+    lessonState.current.push(newLesson);
   }
 }
 
 export function updateLessonInState(updatedLesson: Lesson) {
   if (isWithinOneWeek(lessonWeekStartDate.current, new Date(updatedLesson.datetime))) {
-    lessonState.lessons = lessonState.lessons.map(lesson =>
+    lessonState.current = lessonState.current.map(lesson =>
       lesson.id === updatedLesson.id ? updatedLesson : lesson
     );
   } else {
-    lessonState.lessons = lessonState.lessons.filter(lesson => lesson.id !== updatedLesson.id);
+    lessonState.current = lessonState.current.filter(lesson => lesson.id !== updatedLesson.id);
   }
 }

--- a/frontend-svelte/src/lib/states/lessonWeekStartDate.svelte.ts
+++ b/frontend-svelte/src/lib/states/lessonWeekStartDate.svelte.ts
@@ -1,0 +1,3 @@
+import { getStartOfWeekInUTC } from "$lib/utils/dateUtils";
+
+export const lessonWeekStartDate = $state({current: getStartOfWeekInUTC(new Date())});

--- a/frontend-svelte/src/lib/utils/dateUtils.ts
+++ b/frontend-svelte/src/lib/utils/dateUtils.ts
@@ -11,3 +11,11 @@ export function getStartOfWeekInUTC(date: Date): Date {
     
     return utcSunday;
 }
+
+export function isWithinOneWeek(date1: Date, date2: Date): boolean {
+    const startOfWeek1 = getStartOfWeekInUTC(date1);
+    const startOfWeek2 = getStartOfWeekInUTC(date2);
+    
+    const diffInDays = Math.abs((startOfWeek2.getTime() - startOfWeek1.getTime()) / (1000 * 60 * 60 * 24));
+    return diffInDays < 7;
+}

--- a/frontend-svelte/src/routes/+page.svelte
+++ b/frontend-svelte/src/routes/+page.svelte
@@ -5,9 +5,7 @@
   import SelectWeek from "$lib/components/SelectWeek.svelte";
   import { fetchLessons } from "../api/lesson"
   import { lessonState } from "$lib/states/lessonState.svelte";
-  import { getStartOfWeekInUTC } from "$lib/utils/dateUtils";
-
-  let startDate: Date = $state(getStartOfWeekInUTC(new Date()))
+  import { lessonWeekStartDate } from "$lib/states/lessonWeekStartDate.svelte";
 
   onMount(async () => {
     getLessons();
@@ -17,7 +15,7 @@
     getLessons();
   })
 
-  async function getLessons(date: Date = startDate) {
+  async function getLessons(date: Date = lessonWeekStartDate.current) {
     try {
       let newLessons = await fetchLessons({"initial_date": date.toISOString()});
       if (JSON.stringify(lessonState.lessons) !== JSON.stringify(newLessons)) {
@@ -33,7 +31,7 @@
   <div
     class="flex w-full border-4 border-secondary bg-primary px-16 py-4 shadow ring-accent"
   >
-    <SelectWeek bind:startDate={startDate} />
+    <SelectWeek bind:startDate={lessonWeekStartDate.current} />
     <div class="ml-auto">
       <LessonCreateModal>Create Lesson</LessonCreateModal>
     </div>

--- a/frontend-svelte/src/routes/+page.svelte
+++ b/frontend-svelte/src/routes/+page.svelte
@@ -18,8 +18,8 @@
   async function getLessons(date: Date = lessonWeekStartDate.current) {
     try {
       let newLessons = await fetchLessons({"initial_date": date.toISOString()});
-      if (JSON.stringify(lessonState.lessons) !== JSON.stringify(newLessons)) {
-        lessonState.lessons = newLessons;
+      if (JSON.stringify(lessonState.current) !== JSON.stringify(newLessons)) {
+        lessonState.current = newLessons;
       }
     } catch (error) {
       console.error("Error fetching lessons:", error);
@@ -38,10 +38,10 @@
   </div>
 </div>
 <div class="flex flex-row">
-  {#each lessonState.lessons as lesson, i (lesson.id)}
+  {#each lessonState.current as lesson, i (lesson.id)}
     <div class="flex flex-col space-y-4">
       <LessonCard
-        bind:lesson={lessonState.lessons[i]}
+        bind:lesson={lessonState.current[i]}
       />
     </div>
   {/each}


### PR DESCRIPTION
TODOs completed:
- Moved current week start date state into global state variable
- updating and creating lessons in the lessonState state object now have helper functions to ensure the lessons are only included if the are in the current week
- changed lessonState interface to match svelte standards