### PR TITLE
LO-39: Using the week selector arrows, sometimes the date gets stuck

### DIFF
--- a/frontend-svelte/src/lib/components/SelectWeek.svelte
+++ b/frontend-svelte/src/lib/components/SelectWeek.svelte
@@ -16,6 +16,18 @@
 
 <div class="flex items-center">
     <button class="btn btn-secondary" onclick={() => changeWeek(-7)}>&lt;</button>
-    <input type="date" class="input mx-2 bg-secondary" value={startDate.toISOString().slice(0, 10)} onblur={(e: Event) => updateStartDate(new Date((e.target as HTMLInputElement).value))}/>
+    <input 
+        type="date" 
+        class="input mx-2 bg-secondary" 
+        value={startDate.toISOString().slice(0, 10)} 
+        onblur={(e: Event) => {
+        const value = (e.target as HTMLInputElement).value;
+        if (value) {
+            updateStartDate(new Date((e.target as HTMLInputElement).value));
+        } else {
+            updateStartDate(new Date());
+        }
+        }}
+    />
     <button class="btn btn-secondary" onclick={() => changeWeek(7)}>&gt;</button>
 </div>

--- a/frontend-svelte/src/lib/utils/dateUtils.ts
+++ b/frontend-svelte/src/lib/utils/dateUtils.ts
@@ -2,14 +2,12 @@ export function getStartOfWeekInUTC(date: Date): Date {
     const day = date.getUTCDay();
     const diff = date.getUTCDate() - day;
     const sunday = new Date(date.setDate(diff));
-    
+
     // Set time to midnight local time
     sunday.setHours(0, 0, 0, 0);
     
     // Convert to UTC
-    const utcSunday = new Date(Date.UTC(sunday.getFullYear(), sunday.getMonth(), sunday.getDate(), 0, 0, 0));
-    
-    return utcSunday;
+    return sunday;
 }
 
 export function isWithinOneWeek(date1: Date, date2: Date): boolean {


### PR DESCRIPTION
TODOs completed:
- fixed bug where week selector arrows would not move to the correct date and occasionally get stuck in loops