### PR TITLE
LO-49: Remove LessonCard auto-width max

### DIFF
--- a/frontend-svelte/src/routes/lessons/+page.svelte
+++ b/frontend-svelte/src/routes/lessons/+page.svelte
@@ -25,10 +25,10 @@
     </div>
   </div>
 </div>
-<div class="flex flex-row flex-wrap">
+<div class="flex flex-row flex-wrap gap-2 p-2">
   {#each lessonState.current as lessons}
     {#if lessons.length > 0}
-      <div class="flex flex-col space-y-4 m-2 flex-1">
+      <div class="flex flex-col space-y-4 grow-0 shrink-0 basis-[calc(16.666%_-_0.5rem)]">
         <h2 class="text-lg font-bold">{new Date(lessons[0].datetime).toLocaleDateString("en-US", {weekday: "long"})}</h2>
         {#each lessons as lesson, i (lesson.id)}
           <LessonCard bind:lesson={lessons[i]} />
@@ -37,10 +37,3 @@
     {/if}
   {/each}
 </div>
-
-<style>
-  .flex-1 {
-    flex: 1 1 0;
-    min-width: 15rem; /* Adjust this value as needed */
-  }
-</style>

--- a/frontend-svelte/src/routes/lessons/+page.svelte
+++ b/frontend-svelte/src/routes/lessons/+page.svelte
@@ -28,7 +28,7 @@
 <div class="flex flex-row flex-wrap gap-2 p-2">
   {#each lessonState.current as lessons}
     {#if lessons.length > 0}
-      <div class="flex flex-col space-y-4 grow-0 shrink-0 basis-[calc(16.666%_-_0.5rem)]">
+      <div class="flex flex-col space-y-4 grow-0 shrink-0 sm:basis-[calc(50%_-_1rem)] md:basis-[calc(33.333%_-_1rem)] lg:basis-[calc(16.666%_-_0.5rem)]">
         <h2 class="text-lg font-bold">{new Date(lessons[0].datetime).toLocaleDateString("en-US", {weekday: "long"})}</h2>
         {#each lessons as lesson, i (lesson.id)}
           <LessonCard bind:lesson={lessons[i]} />


### PR DESCRIPTION
TODOs completed:
- LessonCards now take up a set 1/6 of the width on large screens.
- LessonCards are responsive to screen size