### PR TITLE
LO-87: Allow lessons to reference specific students in the edit and create UI

### DIFF
--- a/frontend-svelte/src/api/lessonStudent.ts
+++ b/frontend-svelte/src/api/lessonStudent.ts
@@ -43,3 +43,13 @@ export async function updateLessonStudent(id: number, lessonStudent: Partial<Les
 export async function deleteLessonStudent(id: number): Promise<void> {
     await apiRequest<void>(`/lesson-students/${id}`, 'DELETE');
 }
+
+export async function findLessonStudentByLessonAndStudent(lessonId: number, studentId: number): Promise<LessonStudent | null> {
+    try {
+        const response = await fetchLessonStudents({ lesson_id: lessonId, student_id: studentId });
+        return response.lesson_students.length > 0 ? response.lesson_students[0] : null;
+    } catch (error) {
+        console.error('Error finding lesson-student relationship:', error);
+        return null;
+    }
+}

--- a/frontend-svelte/src/lib/components/LessonCard.svelte
+++ b/frontend-svelte/src/lib/components/LessonCard.svelte
@@ -4,7 +4,9 @@
   import { addLessonToState, lessonState, removeLessonFromState, updateLessonInState } from "$lib/states/lessonState.svelte";
   import type { LessonCreateFields, LessonUpdateFields } from "../../api/lesson";
   import TipexEditor from "./TipexEditor.svelte";
+  import StudentSelector from "./StudentSelector.svelte";
   import { initializeDateTimeInput } from "$lib/utils/dateUtils";
+  import { deleteLessonStudent, findLessonStudentByLessonAndStudent } from "../../api/lessonStudent";
 
   let { lesson = $bindable() }: { lesson: Lesson } = $props();
   let isEditing: boolean = $state(false);
@@ -23,6 +25,8 @@
   let plan: string = $state(lesson.plan ?? "");
   let concepts: string = $state(lesson.concepts ?? "");
   let notes: string = $state(lesson.notes ?? "");
+  let selectedStudents = $state(lesson.students || []);
+  let studentSearchTerm = $state("");
 
   async function handleDelete() {
     await deleteLesson(lesson.id);
@@ -34,7 +38,32 @@
   async function handleConfirm() {
     const datetime = new Date(`${dateInput}T${timeInput}`).toISOString();
     const updatedLesson : LessonUpdateFields = { ...lesson, datetime, plan, concepts, notes };
-    const updated = await updateLesson(lesson.id, updatedLesson, []);
+    const studentIds = selectedStudents.map(s => s.id);
+    
+    // Find students that were removed and delete their LessonStudent relationships
+    const originalStudentIds = lesson.students?.map(s => s.id) || [];
+    const removedStudentIds = originalStudentIds.filter(id => !studentIds.includes(id));
+    
+    if (removedStudentIds.length > 0) {
+      try {
+        // Find and delete each LessonStudent relationship by lesson_id and student_id
+        await Promise.all(
+          removedStudentIds.map(async (studentId) => {
+            const lessonStudent = await findLessonStudentByLessonAndStudent(lesson.id, studentId);
+            if (lessonStudent) {
+              await deleteLessonStudent(lessonStudent.id);
+            } else {
+              console.warn(`LessonStudent relationship not found for lesson ${lesson.id} and student ${studentId}`);
+            }
+          })
+        );
+      } catch (error) {
+        console.error("Error deleting lesson-student relationships:", error);
+      }
+    }
+    
+    // Update the lesson with new student list
+    const updated = await updateLesson(lesson.id, updatedLesson, studentIds);
     updateLessonInState(updated);
     isEditing = false;
   }
@@ -45,6 +74,8 @@
     plan = lesson.plan ?? "";
     concepts = lesson.concepts ?? "";
     notes = lesson.notes ?? "";
+    selectedStudents = lesson.students || [];
+    studentSearchTerm = "";
   }
 
   async function handleCopy() {
@@ -55,7 +86,8 @@
       datetime: combinedDateTime,
     };
 
-    const createdLesson = await createLesson(newLesson);
+    const studentIds = lesson.students?.map(s => s.id) || [];
+    const createdLesson = await createLesson(newLesson, studentIds);
     addLessonToState(createdLesson);
   }
 
@@ -98,7 +130,7 @@
 
   <!-- Delete Confirmation Modal -->
   {#if showDeleteModal}
-    <dialog class="modal modal-open" role="dialog" aria-modal="true" aria-labelledby="delete-modal-title">
+    <dialog class="modal modal-open" aria-modal="true" aria-labelledby="delete-modal-title">
       <div class="modal-box">
         <h3 id="delete-modal-title" class="font-bold text-lg">Confirm Deletion</h3>
         <p class="py-4">Are you sure you want to delete this lesson?</p>
@@ -122,6 +154,101 @@
       </div>
     </div>
   {/if}
+
+  <!-- Students Section -->
+  <StudentSelector 
+    bind:selectedStudents={selectedStudents}
+    bind:studentSearchTerm={studentSearchTerm}
+    isEditing={isEditing}
+  >
+    {#snippet children(ctx)}
+      {#if ctx.isEditing}
+        <!-- Editing Mode - Student Selection Interface -->
+        <div class="flex flex-col space-y-2">
+          <label class="label" for="lesson-card-student-search">
+            <span class="label-text text-secondary">Add Students</span>
+          </label>
+          
+          <!-- Student Search Input -->
+          <div class="relative">
+            <input
+              id="lesson-card-student-search"
+              type="text"
+              placeholder="Search students by name..."
+              bind:value={studentSearchTerm}
+              oninput={ctx.handleStudentSearch}
+              onfocus={() => ctx.showStudentDropdown = studentSearchTerm.length > 0}
+              onblur={() => {
+                setTimeout(() => ctx.showStudentDropdown = false, 150);
+              }}
+              class="input input-bordered w-full bg-neutral text-secondary border-secondary"
+            />
+            
+            <!-- Student Dropdown -->
+            {#if ctx.showStudentDropdown}
+              <div class="absolute z-50 w-full mt-1 bg-neutral border border-secondary rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                {#if ctx.filteredStudents.length > 0}
+                  {#each ctx.filteredStudents as student (student.id)}
+                    <button
+                      type="button"
+                      class="w-full px-4 py-2 text-left hover:bg-secondary hover:text-neutral transition-colors text-secondary"
+                      onclick={() => ctx.addStudent(student)}
+                    >
+                      {student.first_name} {student.last_name || ''}
+                    </button>
+                  {/each}
+                {:else}
+                  <div class="px-4 py-2 text-sm text-secondary opacity-60">
+                    No students found matching "{studentSearchTerm}"
+                  </div>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        </div>
+      {/if}
+      
+      <!-- Selected Students Display (shows in both editing and view mode) -->
+      <div class="bg-neutral shadow-md rounded-lg p-3 min-h-24 mt-2">
+        <span class="text-lg font-medium mb-2 block text-secondary">
+          {ctx.isEditing ? `Selected Students (${ctx.selectedStudents.length}):` : `Students (${ctx.selectedStudents.length}):`}
+        </span>
+        
+        {#if ctx.selectedStudents.length > 0}
+          <div class="flex flex-wrap gap-2">
+            {#each ctx.selectedStudents as student (student.id)}
+              {#if ctx.isEditing}
+                <button
+                  type="button"
+                  class="flex items-center gap-1 bg-neutral shadow-md hover:bg-error hover:text-error-content rounded-full px-3 py-1 text-sm transition-colors cursor-pointer"
+                  onclick={() => ctx.removeStudent(student.id)}
+                  aria-label="Remove {student.first_name} {student.last_name || ''}"
+                  title="Click to remove"
+                >
+                  <span class="truncate max-w-32 text-secondary">{student.first_name} {student.last_name || ''}</span>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 flex-shrink-0 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              {:else}
+                <a
+                  href="/students/{student.id}"
+                  target="_blank"
+                  class="bg-neutral shadow-md rounded-full px-3 py-1 text-sm hover:bg-gray-100 transition-colors cursor-pointer block"
+                >
+                  <span class="truncate max-w-32 text-secondary">{student.first_name} {student.last_name || ''}</span>
+                </a>
+              {/if}
+            {/each}
+          </div>
+        {:else}
+          <div class="text-sm text-secondary opacity-60 italic flex items-center">
+            {ctx.isEditing ? 'No students selected for this lesson' : 'No students assigned to this lesson'}
+          </div>
+        {/if}
+      </div>
+    {/snippet}
+  </StudentSelector>
 
   <!-- Plan Section -->
   <div class="card bg-neutral shadow-md">

--- a/frontend-svelte/src/lib/components/LessonCard.svelte
+++ b/frontend-svelte/src/lib/components/LessonCard.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import type { Lesson } from "../../types";
+  import type { Lesson, Student } from "../../types";
   import { deleteLesson, updateLesson, createLesson } from "../../api/lesson";
   import { addLessonToState, lessonState, removeLessonFromState, updateLessonInState } from "$lib/states/lessonState.svelte";
   import type { LessonCreateFields, LessonUpdateFields } from "../../api/lesson";
   import TipexEditor from "./TipexEditor.svelte";
-  import StudentSelector from "./StudentSelector.svelte";
+  import StudentSelector, { type StudentSelectorContext } from "./StudentSelector.svelte";
   import { initializeDateTimeInput } from "$lib/utils/dateUtils";
   import { deleteLessonStudent, findLessonStudentByLessonAndStudent } from "../../api/lessonStudent";
 
@@ -161,58 +161,62 @@
     bind:studentSearchTerm={studentSearchTerm}
     isEditing={isEditing}
   >
-    {#snippet children(ctx)}
-      {#if ctx.isEditing}
-        <!-- Editing Mode - Student Selection Interface -->
-        <div class="flex flex-col space-y-2">
-          <label class="label" for="lesson-card-student-search">
-            <span class="label-text text-secondary">Add Students</span>
-          </label>
-          
-          <!-- Student Search Input -->
-          <div class="relative">
-            <input
-              id="lesson-card-student-search"
-              type="text"
-              placeholder="Search students by name..."
-              bind:value={studentSearchTerm}
-              oninput={ctx.handleStudentSearch}
-              onfocus={() => ctx.showStudentDropdown = studentSearchTerm.length > 0}
-              onblur={() => {
-                setTimeout(() => ctx.showStudentDropdown = false, 150);
-              }}
-              class="input input-bordered w-full bg-neutral text-secondary border-secondary"
-            />
-            
-            <!-- Student Dropdown -->
-            {#if ctx.showStudentDropdown}
-              <div class="absolute z-50 w-full mt-1 bg-neutral border border-secondary rounded-lg shadow-lg max-h-48 overflow-y-auto">
-                {#if ctx.filteredStudents.length > 0}
-                  {#each ctx.filteredStudents as student (student.id)}
-                    <button
-                      type="button"
-                      class="w-full px-4 py-2 text-left hover:bg-secondary hover:text-neutral transition-colors text-secondary"
-                      onclick={() => ctx.addStudent(student)}
-                    >
-                      {student.first_name} {student.last_name || ''}
-                    </button>
-                  {/each}
-                {:else}
-                  <div class="px-4 py-2 text-sm text-secondary opacity-60">
-                    No students found matching "{studentSearchTerm}"
-                  </div>
-                {/if}
-              </div>
-            {/if}
-          </div>
-        </div>
-      {/if}
-      
+    {#snippet children(ctx: StudentSelectorContext)}
       <!-- Selected Students Display (shows in both editing and view mode) -->
       <div class="bg-neutral shadow-md rounded-lg p-3 min-h-24 mt-2">
         <span class="text-lg font-medium mb-2 block text-secondary">
-          {ctx.isEditing ? `Selected Students (${ctx.selectedStudents.length}):` : `Students (${ctx.selectedStudents.length}):`}
+          {#if ctx.selectedStudents.length <= 1}
+            {ctx.selectedStudents.length === 1 ? 'Student' : 'Students'}
+          {:else}
+            Students ({ctx.selectedStudents.length})
+          {/if}
         </span>
+        
+        {#if ctx.isEditing}
+          <!-- Editing Mode - Student Selection Interface -->
+          <div class="flex flex-col space-y-2 mb-4">
+            <label class="label" for="lesson-card-student-search">
+              <span class="label-text text-secondary">Add Students</span>
+            </label>
+            
+            <!-- Student Search Input -->
+            <div class="relative">
+              <input
+                id="lesson-card-student-search"
+                type="text"
+                placeholder="Search students by name..."
+                bind:value={studentSearchTerm}
+                oninput={ctx.handleStudentSearch}
+                onfocus={() => ctx.showStudentDropdown = studentSearchTerm.length > 0}
+                onblur={() => {
+                  setTimeout(() => ctx.showStudentDropdown = false, 150);
+                }}
+                class="input input-bordered w-full bg-neutral text-secondary border-secondary"
+              />
+              
+              <!-- Student Dropdown -->
+              {#if ctx.showStudentDropdown}
+                <div class="absolute z-50 w-full mt-1 bg-neutral border border-secondary rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                  {#if ctx.filteredStudents.length > 0}
+                    {#each ctx.filteredStudents as student (student.id)}
+                      <button
+                        type="button"
+                        class="w-full px-4 py-2 text-left hover:bg-secondary hover:text-neutral transition-colors text-secondary"
+                        onclick={() => ctx.addStudent(student)}
+                      >
+                        {student.first_name} {student.last_name || ''}
+                      </button>
+                    {/each}
+                  {:else}
+                    <div class="px-4 py-2 text-sm text-secondary opacity-60">
+                      No students found matching "{studentSearchTerm}"
+                    </div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+          </div>
+        {/if}
         
         {#if ctx.selectedStudents.length > 0}
           <div class="flex flex-wrap gap-2">

--- a/frontend-svelte/src/lib/components/LessonCreateModal.svelte
+++ b/frontend-svelte/src/lib/components/LessonCreateModal.svelte
@@ -5,7 +5,7 @@
   import { lessonState, addLessonToState } from "$lib/states/lessonState.svelte";
   import { lessonWeekStartDate } from "$lib/states/lessonWeekStartDate.svelte";
   import TipexEditor from "./TipexEditor.svelte";
-  import StudentSelector from "./StudentSelector.svelte";
+  import StudentSelector, { type StudentSelectorContext } from "./StudentSelector.svelte";
 
   let { children } = $props();
 
@@ -146,7 +146,7 @@
             bind:studentSearchTerm={studentSearchTerm}
             isEditing={true}
           >
-            {#snippet children(ctx)}
+            {#snippet children(ctx: StudentSelectorContext)}
               <div class="flex flex-col space-y-2">
                 <label class="label" for="student-search">
                   <span class="label-text">Students</span>

--- a/frontend-svelte/src/lib/components/LessonCreateModal.svelte
+++ b/frontend-svelte/src/lib/components/LessonCreateModal.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { createLesson } from "../../api/lesson";
   import type { LessonCreateFields } from "../../api/lesson";
-  import type { Lesson } from "../../types";
+  import type { Lesson, Student } from "../../types";
   import { lessonState, addLessonToState } from "$lib/states/lessonState.svelte";
   import { lessonWeekStartDate } from "$lib/states/lessonWeekStartDate.svelte";
+  import { fetchStudents } from "../../api/student";
   import TipexEditor from "./TipexEditor.svelte";
 
   let { children } = $props();
@@ -14,9 +15,83 @@
   let concepts = $state("");
   let notes = $state("");
 
+  // Student selection state
+  let selectedStudents = $state<Student[]>([]);
+  let studentSearchTerm = $state("");
+  let availableStudents = $state<Student[]>([]);
+  let filteredStudents = $state<Student[]>([]);
+  let showStudentDropdown = $state(false);
+  let studentSearchTimeout: number;
+
   let lessonCreateModal: HTMLDialogElement;
   let dateWarning = $state(false);
   let timeWarning = $state(false);
+
+  // Load students when modal opens
+  async function loadStudents() {
+    try {
+      const response = await fetchStudents();
+      availableStudents = response.students;
+      filterStudents();
+    } catch (error) {
+      console.error("Error loading students:", error);
+    }
+  }
+
+  // Filter students based on search term and exclude already selected
+  function filterStudents() {
+    const search = studentSearchTerm.toLowerCase().trim();
+    filteredStudents = availableStudents.filter(student => {
+      const fullName = `${student.first_name} ${student.last_name || ''}`.toLowerCase();
+      const isAlreadySelected = selectedStudents.some(s => s.id === student.id);
+      return fullName.includes(search) && !isAlreadySelected;
+    });
+  }
+
+  // Handle student search input with debouncing
+  function handleStudentSearch() {
+    if (studentSearchTimeout) {
+      clearTimeout(studentSearchTimeout);
+    }
+    studentSearchTimeout = setTimeout(() => {
+      filterStudents();
+      showStudentDropdown = studentSearchTerm.length > 0;
+    }, 200);
+  }
+
+  // Add student to selected list
+  function addStudent(student: Student) {
+    selectedStudents = [...selectedStudents, student];
+    studentSearchTerm = "";
+    showStudentDropdown = false;
+    filterStudents();
+  }
+
+  // Remove student from selected list
+  function removeStudent(studentId: number) {
+    selectedStudents = selectedStudents.filter(s => s.id !== studentId);
+    filterStudents();
+  }
+
+  // Reset form state
+  function resetForm() {
+    date = "";
+    time = "";
+    plan = "";
+    concepts = "";
+    notes = "";
+    selectedStudents = [];
+    studentSearchTerm = "";
+    showStudentDropdown = false;
+    dateWarning = false;
+    timeWarning = false;
+  }
+
+  // Close modal and reset form
+  function closeModal() {
+    resetForm();
+    lessonCreateModal.close();
+  }
 
   async function handleCreateLesson() {
     dateWarning = date === "";
@@ -35,8 +110,10 @@
     };
 
     try {
-      const createdLesson = await createLesson(newLesson);
+      const studentIds = selectedStudents.map(s => s.id);
+      const createdLesson = await createLesson(newLesson, studentIds);
       addLessonToState(createdLesson);
+      resetForm();
       lessonCreateModal.close();
     } catch (error) {
       console.error("Error creating lesson:", error);
@@ -46,12 +123,9 @@
 
 <button
   class="btn btn-secondary"
-  onclick={() => {
-    date = "";
-    time = "";
-    plan = "";
-    concepts = "";
-    notes = "";
+  onclick={async () => {
+    resetForm();
+    await loadStudents();
     lessonCreateModal.showModal();
   }}
 >
@@ -118,16 +192,86 @@
           />
         </div>
         <div class="flex flex-col space-y-4 w-1/2">
-          <!-- Student Section -->
+          <!-- Student Selection Section -->
+          <div class="flex flex-col space-y-2">
+            <label class="label" for="student-search">
+              <span class="label-text">Students</span>
+            </label>
+            
+            <!-- Student Search Input -->
+            <div class="relative">
+              <input
+                id="student-search"
+                type="text"
+                placeholder="Search students by name..."
+                bind:value={studentSearchTerm}
+                oninput={handleStudentSearch}
+                onfocus={() => showStudentDropdown = studentSearchTerm.length > 0}
+                onblur={() => {
+                  // Delay hiding dropdown to allow click events on dropdown items
+                  setTimeout(() => showStudentDropdown = false, 150);
+                }}
+                class="input input-bordered w-full bg-secondary"
+              />
+              
+              <!-- Student Dropdown -->
+              {#if showStudentDropdown}
+                <div class="absolute z-50 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-48 overflow-y-auto">
+                  {#if filteredStudents.length > 0}
+                    {#each filteredStudents as student (student.id)}
+                      <button
+                        type="button"
+                        class="w-full px-4 py-2 text-left hover:bg-base-200 transition-colors"
+                        onclick={() => addStudent(student)}
+                      >
+                        {student.first_name} {student.last_name || ''}
+                      </button>
+                    {/each}
+                  {:else}
+                    <div class="px-4 py-2 text-sm text-base-content opacity-60">
+                      No students found matching "{studentSearchTerm}"
+                    </div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
+            
+            <!-- Selected Students List -->
+            {#if selectedStudents.length > 0}
+              <div class="bg-base-200 rounded-lg p-3 min-h-24">
+                <span class="text-sm font-medium mb-2 block">Selected Students ({selectedStudents.length}):</span>
+                <div class="flex flex-wrap gap-2">
+                  {#each selectedStudents as student (student.id)}
+                    <button
+                      type="button"
+                      class="flex items-center gap-1 bg-base-100 hover:bg-error hover:text-error-content rounded-full px-3 py-1 text-sm transition-colors cursor-pointer"
+                      onclick={() => removeStudent(student.id)}
+                      aria-label="Remove {student.first_name} {student.last_name || ''}"
+                      title="Click to remove"
+                    >
+                      <span class="truncate max-w-32">{student.first_name} {student.last_name || ''}</span>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 flex-shrink-0 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  {/each}
+                </div>
+              </div>
+            {:else}
+              <div class="text-sm text-base-content opacity-60 italic min-h-24 flex items-center">
+                No students selected for this lesson
+              </div>
+            {/if}
+          </div>
         </div>
       </div>
     </div>
     <div class="modal-action">
-      <button class="btn" onclick={() => lessonCreateModal.close()}>Cancel</button>
+      <button class="btn" onclick={closeModal}>Cancel</button>
       <button class="btn btn-primary" onclick={handleCreateLesson}>Create</button>
     </div>
   </div>
   <form method="dialog" class="modal-backdrop">
-    <button>close</button>
+    <button onclick={closeModal}>close</button>
   </form>
 </dialog>

--- a/frontend-svelte/src/lib/components/StudentCard.svelte
+++ b/frontend-svelte/src/lib/components/StudentCard.svelte
@@ -634,7 +634,7 @@
                                 {@const lastLesson = getLastLessonFromStudent(student)}
                                 {#if lastLesson}
                                     <!-- Use LessonCard component -->
-                                    <LessonCard lesson={lastLesson} />
+                                    <LessonCard lessonId={lastLesson.id} />
                                 {:else}
                                     <div class="text-center text-base-content/60 py-4">
                                         <p class="font-medium">No past lessons found</p>

--- a/frontend-svelte/src/lib/components/StudentPanel.svelte
+++ b/frontend-svelte/src/lib/components/StudentPanel.svelte
@@ -458,15 +458,15 @@
                     </tr>
                 {:else}
                     {#each sortedStudents as student (student.id)}
-                        <tr class="hover">
-                            <td>{student.first_name} {student.last_name || ''}</td>
+                        <tr class="hover cursor-pointer hover:bg-primary/5 hover:shadow-sm active:bg-primary/10" onclick={() => openModal(student)}>
+                            <td class="hover:text-primary">{student.first_name} {student.last_name || ''}</td>
                             <td>{getCurrentLevel(student)}</td>
                             <td>{getCurrentStatus(student)}</td>
                             <td>{getNextLesson(student)}</td>
                             <td>{getLastLesson(student)}</td>
                             <td>-</td> <!-- TODO: Add last quiz logic -->
                             <td>
-                                <button class="btn btn-primary btn-sm" onclick={() => openModal(student)}>Edit</button>
+                                <button class="btn btn-primary btn-sm" onclick={(e) => { e.stopPropagation(); openModal(student); }}>Edit</button>
                             </td>
                         </tr>
                     {/each}

--- a/frontend-svelte/src/lib/components/StudentPanel.svelte
+++ b/frontend-svelte/src/lib/components/StudentPanel.svelte
@@ -18,10 +18,8 @@
         levelState,
         refreshLevels,
         getLevelDisplayById,
-        getLevelsByCurriculumId,
         curriculumState,
-        refreshCurriculums,
-        getCurriculumNameById
+        refreshCurriculums
     } from "../states";
 
     let students = $state<Student[]>([]);

--- a/frontend-svelte/src/lib/components/StudentSelector.svelte
+++ b/frontend-svelte/src/lib/components/StudentSelector.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+  import type { Student } from "../../types";
+  import { fetchStudents } from "../../api/student";
+
+  let { 
+    selectedStudents = $bindable(),
+    studentSearchTerm = $bindable(""),
+    isEditing = false,
+    onStudentsChange = () => {},
+    children
+  }: { 
+    selectedStudents: Student[];
+    studentSearchTerm?: string;
+    isEditing?: boolean;
+    onStudentsChange?: (students: Student[]) => void;
+    children?: any;
+  } = $props();
+
+  // Student selection state - exposed via context or direct access
+  let availableStudents = $state<Student[]>([]);
+  let filteredStudents = $state<Student[]>([]);
+  let showStudentDropdown = $state(false);
+  let studentSearchTimeout: number;
+
+  // Load students when component mounts or when isEditing becomes true
+  $effect(() => {
+    if (isEditing) {
+      loadStudents();
+    }
+  });
+
+  // Load students from API
+  async function loadStudents() {
+    try {
+      const response = await fetchStudents();
+      availableStudents = response.students;
+      filterStudents();
+    } catch (error) {
+      console.error("Error loading students:", error);
+    }
+  }
+
+  // Filter students based on search term and exclude already selected
+  function filterStudents() {
+    const search = studentSearchTerm.toLowerCase().trim();
+    filteredStudents = availableStudents.filter((student: Student) => {
+      const fullName = `${student.first_name} ${student.last_name || ''}`.toLowerCase();
+      const isAlreadySelected = selectedStudents.some((s: Student) => s.id === student.id);
+      return fullName.includes(search) && !isAlreadySelected;
+    });
+  }
+
+  // Handle student search input with debouncing
+  function handleStudentSearch() {
+    if (studentSearchTimeout) {
+      clearTimeout(studentSearchTimeout);
+    }
+    studentSearchTimeout = setTimeout(() => {
+      filterStudents();
+      showStudentDropdown = studentSearchTerm.length > 0;
+    }, 200);
+  }
+
+  // Add student to selected list
+  function addStudent(student: Student) {
+    selectedStudents = [...selectedStudents, student];
+    studentSearchTerm = "";
+    showStudentDropdown = false;
+    filterStudents();
+    onStudentsChange(selectedStudents);
+  }
+
+  // Remove student from selected list
+  function removeStudent(studentId: number) {
+    selectedStudents = selectedStudents.filter((s: Student) => s.id !== studentId);
+    filterStudents();
+    onStudentsChange(selectedStudents);
+  }
+
+  // Expose functions and state to parent via snippet parameters
+  const context = $derived({
+    studentSearchTerm,
+    filteredStudents,
+    showStudentDropdown,
+    handleStudentSearch,
+    addStudent,
+    removeStudent,
+    isEditing,
+    selectedStudents
+  });
+</script>
+
+<!-- Render children with context -->
+{@render children?.(context)}

--- a/frontend-svelte/src/lib/components/StudentSelector.svelte
+++ b/frontend-svelte/src/lib/components/StudentSelector.svelte
@@ -2,6 +2,18 @@
   import type { Student } from "../../types";
   import { fetchStudents } from "../../api/student";
 
+  // Type for StudentSelector context - exported for use in parent components
+  export interface StudentSelectorContext {
+    studentSearchTerm: string;
+    filteredStudents: Student[];
+    showStudentDropdown: boolean;
+    handleStudentSearch: () => void;
+    addStudent: (student: Student) => void;
+    removeStudent: (studentId: number) => void;
+    isEditing: boolean;
+    selectedStudents: Student[];
+  }
+
   let { 
     selectedStudents = $bindable(),
     studentSearchTerm = $bindable(""),

--- a/frontend-svelte/src/routes/lessons/+page.svelte
+++ b/frontend-svelte/src/routes/lessons/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import LessonCard from "$lib/components/LessonCard.svelte";
   import LessonCreateModal from "$lib/components/LessonCreateModal.svelte";
   import SelectWeek from "$lib/components/SelectWeek.svelte";
@@ -8,11 +7,8 @@
   import ExportWeek from "$lib/components/ExportWeek.svelte";
   import ImportWeek from "$lib/components/ImportWeek.svelte";
 
-  onMount(async () => {
-    await fetchCurrentWeekLessons();
-  });
-
-  $effect(() => {
+  // Fetch lessons on mount and when week changes
+  $effect.pre(() => {
     fetchCurrentWeekLessons();
   });
 </script>
@@ -35,7 +31,7 @@
       <div class="flex flex-col space-y-4 grow-0 shrink-0 sm:basis-[calc(50%_-_1rem)] md:basis-[calc(33.333%_-_1rem)] lg:basis-[calc(16.666%_-_0.5rem)]">
         <h2 class="text-lg font-bold">{new Date(lessons[0].datetime).toLocaleDateString("en-US", {weekday: "long"})}</h2>
         {#each lessons as lesson, i (lesson.id)}
-          <LessonCard bind:lesson={lessons[i]} />
+          <LessonCard lessonId={lesson.id} />
         {/each}
       </div>
     {/if}


### PR DESCRIPTION
Todos completed:
- Added LessonStudent entry creation, editing, and deletion via LessonCreateModal and LessonCard.
- Updated LessonCard to accept a lesson id rather than a lesson object so that it can fetch its own data which includes relationships (fixing a bug with StudentCards passing the lesson from the relationship which contains no relationship information.
- Update UI of StudentPanel to allow for sorting by each column.
- Updated table rows in StudentPanel to allow for clicking anywhere to open the modal.